### PR TITLE
Update Default For mount_tmp_options

### DIFF
--- a/container.hardened.inputs.yml
+++ b/container.hardened.inputs.yml
@@ -4,35 +4,6 @@
 # Controls that are known to consistently have long run times can be disabled with this attribute
 disable_slow_controls: false
 
-# V-72081 - 'monitor_kernel_log', (bool)
-# Set this to false if your system availability concern is not documented or
-# there is no monitoring of the kernel log
-monitor_kernel_log: true
-
-# V-71849
-# list of system files that should be allowed to change from an rpm verify point of view
-rpm_verify_perms_except: []
-
-# V-71855
-# list of system files that should be allowed to change from an rpm verify point of view
-rpm_verify_integrity_except: []
-
-# V-71859 (already set to true)
-banner_message_enabled: true
-
-# V-72211 (default: false)
-log_aggregation_server: false
-
-# V-72047 (default: [])
-# Known application groups that are allowed to have world-writeable files or directories
-application_groups: []
-
-# V-72307
-x11_enabled: false
-
-# Accounts that are not allowed on the system (Array)
-disallowed_accounts: ["games", "gopher", "ftp"]
-
 # Accounts of known managed users (Array)
 user_accounts: ["ec2-user"]
 
@@ -53,11 +24,6 @@ known_system_accounts:
     "systemd-bus-proxy",
     "ec2-user",
   ]
-
-# V-71859/V-77819
-# User to use to check dconf settings
-# (Nil means to use whatever user is running inspec currently)
-dconf_user: nil
 
 #  You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
 #  By using this IS (which includes any device attached to this IS), you consent to the following conditions:
@@ -89,8 +55,6 @@ banner_message_text_gui:
   communications and work product are private and confidential. See User \
   Agreement for details."
 
-banner_message_text_gui_limited: "I've read & consent to terms in IS user agreem't."
-
 # V-71863
 # whitespace is ignored
 banner_message_text_cli:
@@ -112,8 +76,6 @@ banner_message_text_cli:
   services by attorneys, psychotherapists, or clergy, and their assistants. Such \
   communications and work product are private and confidential. See User \
   Agreement for details."
-
-banner_message_text_cli_limited: "I've read & consent to terms in IS user agreem't."
 
 # V-72225
 # whitespace is ignored
@@ -137,12 +99,6 @@ banner_message_text_ral:
   communications and work product are private and confidential. See User \
   Agreement for details."
 
-banner_message_text_ral_limited: "I've read & consent to terms in IS user agreem't."
-
-# V-71901
-# The scereensaver lock-delay must be less than or equal to the specified value
-lock_delay: 5
-
 # V-71911
 # minimum number of characters that must be different from previous password
 difok: 8
@@ -151,9 +107,8 @@ difok: 8
 # number of reuse generations
 min_reuse_generations: 5
 
-# V-71935
 # (number of characters)
-min_len: 15
+pass_min_len: 15
 
 # V-71941
 # (number of days)
@@ -174,24 +129,14 @@ lockout_time: 604800
 # V-71973
 # name of tool
 file_integrity_tool: "aide"
-# (monthly, weekly, or daily)
-file_integrity_interval: "weekly"
 
 # V-72223
 # (time in seconds)
 system_activity_timeout: 600
 
-# V-72237
-# (time in seconds)
-client_alive_interval: 600
-
 # V-71965, V-72417, V-72433
 # (enabled or disabled)
 smart_card_enabled: false
-
-# V-72051/V-72209
-# The path to the logging package
-log_pkg_path: "/etc/rsyslog.conf"
 
 # V-72011, V-72015, V-72017, V-72019, V-72021, V-72023, V-72025
 # V-72027, V-72029, V-72031, V-72033, V-72035, V-72037, V-72059
@@ -203,50 +148,14 @@ exempt_home_users: []
 # main grub boot config file
 grub_main_cfg: "/boot/grub2/grub.cfg"
 
-# superusers for grub boot ( array )
-grub_superusers: ["root", "ec2-user"]
-
 # grub boot config files
 grub_user_boot_files: ["/boot/grub2/user.cfg"]
-
-# V-71963
-# superusers for efi boot ( array )
-efi_superusers: ["root", ec2-user]
 
 # efi boot config files
 efi_user_boot_files: ["/boot/efi/EFI/redhat/user.cfg"]
 
 # main efi boot config file
 efi_main_cfg: "/boot/efi/EFI/redhat/grub.cfg"
-
-# V-71971
-# system accounts that support approved system activities
-admin_logins: []
-
-# V-72417
-# the list of packages needed for MFA on RHEL
-mfa_pkg_list:
-  [
-    "nss-tools",
-    "nss-pam-ldapd",
-    "esc",
-    "pam_pkcs11",
-    "pam_krb5",
-    "opensc",
-    "pcsc-lite-ccid",
-    "gdm",
-    "authconfig",
-    "authconfig-gtk",
-    "krb5-libs",
-    "krb5-workstation",
-    "krb5-pkinit",
-    "pcsc-lite",
-    "pcsc-lite-libs",
-  ]
-
-# V-77819
-# should dconf have smart card authentication
-multifactor_enabled: false
 
 # these shells do not allow a user to login
 non_interactive_shells:
@@ -266,14 +175,5 @@ randomize_va_space: 2
 # V-72043
 # file systems that don't correspond to removable media
 non_removable_media_fs: ["xfs", "ext4", "swap", "tmpfs"]
-
-# V-72317
-# approved configured tunnels prepended with word 'conn'
-# Example: ['conn myTunnel']
-approved_tunnels: []
-
-# V-72039
-# Is the target expected to be a virtual machine
-virtual_machine: true
 
 allow_container_openssh_server: false

--- a/container.vanilla.inputs.yml
+++ b/container.vanilla.inputs.yml
@@ -4,35 +4,6 @@
 # Controls that are known to consistently have long run times can be disabled with this attribute
 disable_slow_controls: false
 
-# V-72081 - 'monitor_kernel_log', (bool)
-# Set this to false if your system availability concern is not documented or
-# there is no monitoring of the kernel log
-monitor_kernel_log: true
-
-# V-71849
-# list of system files that should be allowed to change from an rpm verify point of view
-rpm_verify_perms_except: []
-
-# V-71855
-# list of system files that should be allowed to change from an rpm verify point of view
-rpm_verify_integrity_except: []
-
-# V-71859 (already set to true)
-banner_message_enabled: true
-
-# V-72211 (default: false)
-log_aggregation_server: false
-
-# V-72047 (default: [])
-# Known application groups that are allowed to have world-writeable files or directories
-application_groups: []
-
-# V-72307
-x11_enabled: false
-
-# Accounts that are not allowed on the system (Array)
-disallowed_accounts: ["games", "gopher", "ftp"]
-
 # Accounts of known managed users (Array)
 user_accounts: ["ec2-user"]
 
@@ -53,11 +24,6 @@ known_system_accounts:
     "systemd-bus-proxy",
     "ec2-user",
   ]
-
-# V-71859/V-77819
-# User to use to check dconf settings
-# (Nil means to use whatever user is running inspec currently)
-dconf_user: nil
 
 #  You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
 #  By using this IS (which includes any device attached to this IS), you consent to the following conditions:
@@ -89,8 +55,6 @@ banner_message_text_gui:
   communications and work product are private and confidential. See User \
   Agreement for details."
 
-banner_message_text_gui_limited: "I've read & consent to terms in IS user agreem't."
-
 # V-71863
 # whitespace is ignored
 banner_message_text_cli:
@@ -112,8 +76,6 @@ banner_message_text_cli:
   services by attorneys, psychotherapists, or clergy, and their assistants. Such \
   communications and work product are private and confidential. See User \
   Agreement for details."
-
-banner_message_text_cli_limited: "I've read & consent to terms in IS user agreem't."
 
 # V-72225
 # whitespace is ignored
@@ -137,12 +99,6 @@ banner_message_text_ral:
   communications and work product are private and confidential. See User \
   Agreement for details."
 
-banner_message_text_ral_limited: "I've read & consent to terms in IS user agreem't."
-
-# V-71901
-# The scereensaver lock-delay must be less than or equal to the specified value
-lock_delay: 5
-
 # V-71911
 # minimum number of characters that must be different from previous password
 difok: 8
@@ -151,9 +107,8 @@ difok: 8
 # number of reuse generations
 min_reuse_generations: 5
 
-# V-71935
 # (number of characters)
-min_len: 15
+pass_min_len: 15
 
 # V-71941
 # (number of days)
@@ -174,24 +129,14 @@ lockout_time: 604800
 # V-71973
 # name of tool
 file_integrity_tool: "aide"
-# (monthly, weekly, or daily)
-file_integrity_interval: "weekly"
 
 # V-72223
 # (time in seconds)
 system_activity_timeout: 600
 
-# V-72237
-# (time in seconds)
-client_alive_interval: 600
-
 # V-71965, V-72417, V-72433
 # (enabled or disabled)
 smart_card_enabled: false
-
-# V-72051/V-72209
-# The path to the logging package
-log_pkg_path: "/etc/rsyslog.conf"
 
 # V-72011, V-72015, V-72017, V-72019, V-72021, V-72023, V-72025
 # V-72027, V-72029, V-72031, V-72033, V-72035, V-72037, V-72059
@@ -203,50 +148,14 @@ exempt_home_users: []
 # main grub boot config file
 grub_main_cfg: "/boot/grub2/grub.cfg"
 
-# superusers for grub boot ( array )
-grub_superusers: ["root", "ec2-user"]
-
 # grub boot config files
 grub_user_boot_files: ["/boot/grub2/user.cfg"]
-
-# V-71963
-# superusers for efi boot ( array )
-efi_superusers: ["root", ec2-user]
 
 # efi boot config files
 efi_user_boot_files: ["/boot/efi/EFI/redhat/user.cfg"]
 
 # main efi boot config file
 efi_main_cfg: "/boot/efi/EFI/redhat/grub.cfg"
-
-# V-71971
-# system accounts that support approved system activities
-admin_logins: []
-
-# V-72417
-# the list of packages needed for MFA on RHEL
-mfa_pkg_list:
-  [
-    "nss-tools",
-    "nss-pam-ldapd",
-    "esc",
-    "pam_pkcs11",
-    "pam_krb5",
-    "opensc",
-    "pcsc-lite-ccid",
-    "gdm",
-    "authconfig",
-    "authconfig-gtk",
-    "krb5-libs",
-    "krb5-workstation",
-    "krb5-pkinit",
-    "pcsc-lite",
-    "pcsc-lite-libs",
-  ]
-
-# V-77819
-# should dconf have smart card authentication
-multifactor_enabled: false
 
 # these shells do not allow a user to login
 non_interactive_shells:
@@ -266,14 +175,5 @@ randomize_va_space: 2
 # V-72043
 # file systems that don't correspond to removable media
 non_removable_media_fs: ["xfs", "ext4", "swap", "tmpfs"]
-
-# V-72317
-# approved configured tunnels prepended with word 'conn'
-# Example: ['conn myTunnel']
-approved_tunnels: []
-
-# V-72039
-# Is the target expected to be a virtual machine
-virtual_machine: true
 
 allow_container_openssh_server: true

--- a/inspec.yml
+++ b/inspec.yml
@@ -558,12 +558,6 @@ inputs:
       communications and work product are private and confidential. See User \
       Agreement for details."
 
-  # SV-230346
-  - name: maxlogins_limit
-    description: Amount of max logins allowed
-    type: Numeric
-    value: 10
-
   # SV-230335
   - name: fail_interval
     description: Interval of time in which the consecutive failed logon attempts must occur in order for the account to be locked out (time in seconds)
@@ -703,12 +697,6 @@ inputs:
     type: String
     value: "ocsp_dgst=sha1"
 
-  # SV-230372
-  - name: sssd_conf_path
-    description: Path of the sssd_conf file
-    type: String
-    value: /etc/sssd/sssd.conf
-
   # SV-230398
   - name: var_log_audit_group
     description: Group owner of /var/log/audit/audit.log
@@ -764,12 +752,6 @@ inputs:
       nodev: true
       nosuid: true
       noexec: true
-
-  # SV-230271
-  - name: skip_password_privilege_escalation
-    description: rhel_08_010380 - RHEL 8 must require users to provide a password for privilege escalation.
-    type: Boolean
-    value: false
 
   # SV-245540
   - name: skip_endpoint_security_tool
@@ -908,12 +890,6 @@ inputs:
   # SV-230558
   - name: ftp_required
     description: Set to true if there is a documented requirement for the target system to use FTP
-    type: Boolean
-    value: false
-
-  # SV-230554
-  - name: promiscuous_mode_required
-    description: Set to true if there is a documented requirement for the target system to use promiscuous mode
     type: Boolean
     value: false
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -761,7 +761,7 @@ inputs:
     description: rhel_08_04012[3-5] - RHEL 8 must mount /tmp with the (nodev|nosuid|noexec) option.
     type: Hash
     value:
-      nodev: false
+      nodev: true
       nosuid: false
       noexec: false
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -762,8 +762,8 @@ inputs:
     type: Hash
     value:
       nodev: true
-      nosuid: false
-      noexec: false
+      nosuid: true
+      noexec: true
 
   # SV-230271
   - name: skip_password_privilege_escalation

--- a/inspec.yml
+++ b/inspec.yml
@@ -456,12 +456,6 @@ inputs:
     type: String
     value: "/etc/sssd/pki/sssd_auth_ca_db.pem"
 
-  # SV-230333
-  - name: unsuccessful_attempts
-    description: Maximum number of unsuccessful attempts before lockout
-    type: Numeric
-    value: 3
-
   # SV-230353
   - name: system_inactivity_timeout
     description: Maximum system inactivity timeout (time in seconds).

--- a/kitchen.inputs.yml
+++ b/kitchen.inputs.yml
@@ -6,7 +6,6 @@ mount_tmp_options:
   nodev: true
   nosuid: true
   noexec: true
-skip_password_privilege_escalation: false
 skip_endpoint_security_tool: false
 network_router: false
 use_fapolicyd: true

--- a/kitchen.inputs.yml
+++ b/kitchen.inputs.yml
@@ -2,7 +2,7 @@
 disable_slow_controls: false
 disconnected_system: false
 data_at_rest_exempt: false
-skip_mount_tmp:
+mount_tmp_options:
   nodev: true
   nosuid: true
   noexec: true


### PR DESCRIPTION
- change default for mount_tmp_options to check that nodev is in the list according to the default STIG requirement
relevant to 
SV-230511
SV-230512
SV-230513

- Updated the name in the kitchen.inputs.yml file for the mount_tmp_options input because it was named something old.

- Also removed some unused inputs from the inspec.yml file:
maxlogins_limit
sssd_conf_path
skip_password_privilege_escalation
promiscuous_mode_required

- Also removed the inputs defined in container.*.inputs.yml files that are not defined in the inspec.yml file.
