### PR TITLE
Input for SV-230554

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -881,6 +881,12 @@ inputs:
     type: Boolean
     value: false
 
+  # SV-230554
+  - name: promiscuous_mode_permitted
+    description: Set to true if there is a documented requirement for the target system to use promiscuous mode
+    type: Boolean
+    value: false
+
   # SV-230533
   - name: tftp_required
     description: Set to true if there is a documented requirement for the target system to use TFTP


### PR DESCRIPTION
added back the input used with proper name based on use in control
The input had been referenced in the inspec.yml file as `promiscuous_mode_required`, which was not used in the controls. However, control SV-230554 used the input `promiscuous_mode_permitted` which was not defined in the inspec.yml file. This PR is to define it as needed in the inspec.yml file.