### PR TITLE
Update sv-230279 to check if slub_debug param CONTAINS 'P'

### DIFF
--- a/controls/SV-230279.rb
+++ b/controls/SV-230279.rb
@@ -58,7 +58,6 @@ configuration survives kernel updates:
   }
 
   grub_stdout = command('grub2-editenv - list').stdout
-  # Check if 
   setting = /slub_debug\s*=\s*.*P.*/
 
   describe 'GRUB config' do

--- a/controls/SV-230279.rb
+++ b/controls/SV-230279.rb
@@ -23,7 +23,7 @@ $ sudo grub2-editenv list | grep slub_debug
 
 kernelopts=root=/dev/mapper/rhel-root ro crashkernel=auto resume=/dev/mapper/rhel-swap rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet fips=1 slub_debug=P page_poison=1 vsyscall=none audit=1 audit_backlog_limit=8192 boot=UUID=8d171156-cd61-421c-ba41-1c021ac29e82
 
-If "slub_debug" is not set to "P" or is missing, this is a finding.
+If "slub_debug" does not contain "P" or is missing, this is a finding.
 
 Check that poisoning of SLUB/SLAB objects is enabled by default to persist in kernel updates:
 
@@ -31,7 +31,7 @@ $ sudo grep slub_debug /etc/default/grub
 
 GRUB_CMDLINE_LINUX="slub_debug=P"
 
-If "slub_debug" is not set to "P", is missing or commented out, this is a finding.'
+If "slub_debug" does not contain "P" or is missing, this is a finding.'
   desc 'fix', 'Configure RHEL 8 to enable poisoning of SLUB/SLAB objects with the
 following commands:
 
@@ -46,7 +46,7 @@ configuration survives kernel updates:
   tag gtitle: 'SRG-OS-000134-GPOS-00068'
   tag satisfies: ['SRG-OS-000134-GPOS-00068', 'SRG-OS-000433-GPOS-00192']
   tag gid: 'V-230279'
-  tag rid: 'SV-230279r792888_rule'
+  tag rid: 'SV-230279r951598_rule'
   tag stig_id: 'RHEL-08-010423'
   tag fix_id: 'F-32923r567584_fix'
   tag cci: ['CCI-001084']
@@ -58,7 +58,8 @@ configuration survives kernel updates:
   }
 
   grub_stdout = command('grub2-editenv - list').stdout
-  setting = /slub_debug\s*=\s*P/
+  # Check if 
+  setting = /slub_debug\s*=\s*.*P.*/
 
   describe 'GRUB config' do
     it 'should enable page poisoning' do


### PR DESCRIPTION
New release of RHEL8 DISA STIG has modified the SV-230279 control to check if the slub_debug parameter in the /etc/default/grub file CONTAINS 'P' instead of being EQUAL TO 'P'

This is because the slub_debug parameter can contain multiple parameter values in order to enable different debugging , such as 'PFA' or 'FZ'

Regular expression for reading the parameter has been updated to reflect this.

Reference:
https://www.[kernel.org/doc/Documentation/vm/slub.txt](https://www.kernel.org/doc/Documentation/vm/slub.txt)