### PR TITLE
Replaced `squish` (rails method) to `strip` to fix a profile error

### DIFF
--- a/controls/SV-244540.rb
+++ b/controls/SV-244540.rb
@@ -26,12 +26,12 @@ If output is produced, this is a finding.'
 
   pam_auth_files = input('pam_auth_files')
   file_list = pam_auth_files.values.join(' ')
-  bad_entries = command("grep -i nullok #{file_list}").stdout.lines.collect(&:squish)
+  bad_entries = command("grep -i nullok #{file_list}").stdout.lines.map(&:strip)
 
-  describe 'The system is configureed' do
+  describe 'The system should be configureed' do
     subject { command("grep -i nullok #{file_list}") }
     it 'to not allow null passwords' do
-      expect(subject.stdout.strip).to be_empty, "The system is configured to allow null passwords. Please remove any instances of the `nullok` option from: \n\t- #{bad_entries.join("\n\t- ")}"
+      expect(subject.stdout.strip).to be_empty, "The system is configured to allow null passwords. Please remove any instances of the `nullok` option from auth files: \n\t- #{bad_entries.join("\n\t- ")}"
     end
   end
 end


### PR DESCRIPTION
Fixes #29 

On GitHub codespaces:
- [First report](https://github.com/user-attachments/files/17299340/redhat8.json)
- [Fixed report](https://github.com/user-attachments/files/17299343/redhat8-fixed.json)



![Screenshot 2024-10-08 at 5 07 54 PM](https://github.com/user-attachments/assets/92ad0f76-3c0e-40cd-bb9a-efbade52936a)
