### PR TITLE
Adjust Chrony_Conf Control

### DIFF
--- a/controls/SV-230484.rb
+++ b/controls/SV-230484.rb
@@ -81,7 +81,7 @@ the following line in the /etc/chrony.conf file.
   time_sources = chrony_conf.server
 
   # Cover case when a single server is defined and resource returns a string and not an array
-  time_sources = [time_sources] if time_sources.is_a? String
+  time_sources = [time_sources].flatten
 
   # Get and map maxpoll values to an array
   unless time_sources.nil?
@@ -97,15 +97,10 @@ the following line in the /etc/chrony.conf file.
 
   unless time_sources.nil?
     # Check if each server in the server array exists in the input
-    valid_time_source_present = time_sources.any? { |server| authoritative_timeserver.include?(server) }
+    valid_time_source_present = time_sources.any? { |server, index| authoritative_timeserver.include?(server) && max_poll_values[index] < 17 }
     describe 'chrony.conf includes at least one valid timeserver' do
       subject { valid_time_source_present }
       it { should be true }
-    end
-    # All time sources must contain valid maxpoll entries
-    describe 'chronyd maxpoll values (99=maxpoll absent)' do
-      subject { max_poll_values }
-      it { should all be < 17 }
     end
   end
 end

--- a/controls/SV-230484.rb
+++ b/controls/SV-230484.rb
@@ -75,7 +75,7 @@ the following line in the /etc/chrony.conf file.
 
   # Get inputs
   authoritative_timeservers = input('authoritative_timeservers')
-  authoritative_timeservers_exact = input('authoritative_timeservers_exact')
+  match_all_authoritative_timeservers_enabled = input('match_all_authoritative_timeservers_enabled')
 
   # Get the system server values
   # Converts to array if only one value present
@@ -104,16 +104,16 @@ the following line in the /etc/chrony.conf file.
     # Check for valid maxpoll value <17
     describe 'chrony.conf' do
       # authoritative_timeservers_exact specifies whether to verify all inputted timeservers or just one
-      if authoritative_timeservers_exact
+      if match_all_authoritative_timeservers_enabled
         it 'should include all specified valid timeservers' do
           expect(authoritative_timeservers.all? { |input|
-                   server_values.include?(input) && max_poll_values[server_values.index(input)] < 17
+                   server_values.include?(input) && max_poll_values[server_values.index(input)] <= 16
                  }).to be true
         end
       else
         it 'should include at least one valid timeserver' do
           expect(authoritative_timeservers.any? { |input|
-            server_values.include?(input) && max_poll_values[server_values.index(input)] < 17
+            server_values.include?(input) && max_poll_values[server_values.index(input)] <= 16
           }).to be true
         end
       end

--- a/controls/SV-230484.rb
+++ b/controls/SV-230484.rb
@@ -73,7 +73,6 @@ the following line in the /etc/chrony.conf file.
     !virtualization.system.eql?('docker')
   }
 
-
   # Get input, convert to array if string
   authoritative_timeserver = input('authoritative_timeserver')
   authoritative_timeserver = [authoritative_timeserver] if authoritative_timeserver.is_a? String

--- a/controls/SV-230484.rb
+++ b/controls/SV-230484.rb
@@ -102,26 +102,21 @@ the following line in the /etc/chrony.conf file.
   unless time_sources.nil?
     # Verify the chrony.conf file is configured to at least one authoritative DoD time source
     # Check for valid maxpoll value <17
-    describe "chrony.conf" do
+    describe 'chrony.conf' do
       # authoritative_timeservers_exact specifies whether to verify all inputted timeservers or just one
       if authoritative_timeservers_exact
-        it "should include all specified valid timeservers" do
+        it 'should include all specified valid timeservers' do
           expect(authoritative_timeservers.all? { |input|
-            server_values.include?(input) && max_poll_values[server_values.index(input)] < 17
-        }).to be true
-      end
+                   server_values.include?(input) && max_poll_values[server_values.index(input)] < 17
+                 }).to be true
+        end
       else
-        it "should include at least one valid timeserver" do
-          expect(authoritative_timeservers.any? { |input| 
-          server_values.include?(input) && max_poll_values[server_values.index(input)] < 17
+        it 'should include at least one valid timeserver' do
+          expect(authoritative_timeservers.any? { |input|
+            server_values.include?(input) && max_poll_values[server_values.index(input)] < 17
           }).to be true
         end
       end
     end
   end
-
 end
-
-
-
-

--- a/controls/SV-230484.rb
+++ b/controls/SV-230484.rb
@@ -97,10 +97,10 @@ the following line in the /etc/chrony.conf file.
 
   unless time_sources.nil?
     # Check if each server in the server array exists in the input
-    time_sources.each do |server|
-      describe server do
-        it { should be_in authoritative_timeserver }
-      end
+    valid_time_source_present = time_sources.any? { |server| authoritative_timeserver.include?(server) }
+    describe 'chrony.conf includes at least one valid timeserver' do
+      subject { valid_time_source_present }
+      it { should be true }
     end
     # All time sources must contain valid maxpoll entries
     describe 'chronyd maxpoll values (99=maxpoll absent)' do

--- a/inspec.yml
+++ b/inspec.yml
@@ -441,10 +441,16 @@ inputs:
     value: "aide"
 
   # SV-230484
-  - name: authoritative_timeserver
-    description: Timeserver used in /etc/chrony.conf
-    type: String
-    value: 0.us.pool.ntp.mil
+  - name: authoritative_timeservers
+    description: Timeserver(s) used in /etc/chrony.conf
+    type: Array
+    value: ["0.us.pool.ntp.mil"]
+  
+  # SV-230484
+  - name: authoritative_timeservers_exact
+    description: Specify that all timeservers in authoritative_timeservers must be present and valid
+    type: Boolean
+    value: false
 
   # SV-230537
   - name: non_removable_media_fs

--- a/inspec.yml
+++ b/inspec.yml
@@ -447,7 +447,7 @@ inputs:
     value: ["0.us.pool.ntp.mil"]
   
   # SV-230484
-  - name: authoritative_timeservers_exact
+  - name: match_all_authoritative_timeservers_enabled
     description: Specify that all timeservers in authoritative_timeservers must be present and valid
     type: Boolean
     value: false


### PR DESCRIPTION
Adjusts control to account for multiple values / arrays in both the inspec.yml input and the chrony.conf configuration file.

Edge case: 
This control passes when the chrony.conf file has fewer servers than the inspec.yml input but all values are valid.

      chrony_conf.server = [10.90.21.160]
      input('authoritative_timeserver') = [10.90.21.160, 10.90.21.178]

^ this would result in a pass.

This may be desirable if user wants to have several possible correct values but the configuration file only needs to have a subset of those values.