### PR TITLE
Update use of actions/upload-artifact@v3 to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/verify-container.yml
+++ b/.github/workflows/verify-container.yml
@@ -85,8 +85,9 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
+          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
+          overwrite: true
 
       - name: Upload ${{ matrix.suite }} to Heimdall
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}

--- a/.github/workflows/verify-container.yml
+++ b/.github/workflows/verify-container.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Save Test Result JSON
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/

--- a/.github/workflows/verify-disa-hardened-ec2.yml
+++ b/.github/workflows/verify-disa-hardened-ec2.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Save Test Result JSON
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/

--- a/.github/workflows/verify-disa-hardened-ec2.yml
+++ b/.github/workflows/verify-disa-hardened-ec2.yml
@@ -84,8 +84,9 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
+          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
+          overwrite: true
 
       - name: Upload ${{ matrix.suite }} to Heimdall
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -85,7 +85,7 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
+          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
           overwrite: true
 

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Save Test Result JSON
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/
+          overwrite: true
 
       - name: Upload ${{ matrix.suite }} to Heimdall
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}

--- a/.github/workflows/verify-rhel-official-hardened-ec2.yml
+++ b/.github/workflows/verify-rhel-official-hardened-ec2.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Save Test Result JSON
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/

--- a/.github/workflows/verify-rhel-official-hardened-ec2.yml
+++ b/.github/workflows/verify-rhel-official-hardened-ec2.yml
@@ -84,8 +84,9 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
+          name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
+          overwrite: true
 
       - name: Upload ${{ matrix.suite }} to Heimdall
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}


### PR DESCRIPTION
Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025