### PR TITLE
Remove overwrite: true flag for actions/upload-artifact v4

### DIFF
--- a/.github/workflows/verify-container.yml
+++ b/.github/workflows/verify-container.yml
@@ -87,7 +87,6 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
-          overwrite: true
 
       - name: Upload ${{ matrix.suite }} to Heimdall
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}

--- a/.github/workflows/verify-disa-hardened-ec2.yml
+++ b/.github/workflows/verify-disa-hardened-ec2.yml
@@ -86,7 +86,6 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
-          overwrite: true
 
       - name: Upload ${{ matrix.suite }} to Heimdall
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -87,7 +87,6 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
-          overwrite: true
 
       - name: Upload ${{ matrix.suite }} to Heimdall
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}

--- a/.github/workflows/verify-rhel-official-hardened-ec2.yml
+++ b/.github/workflows/verify-rhel-official-hardened-ec2.yml
@@ -86,7 +86,6 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-${{ matrix.suite }}-results
           path: spec/results/
-          overwrite: true
 
       - name: Upload ${{ matrix.suite }} to Heimdall
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}


### PR DESCRIPTION
Follow-up to https://github.com/mitre/redhat-enterprise-linux-8-stig-baseline/pull/33. This PR removes the `overwrite: true` flag for actions/upload-artifact v4 since the `name: ...` key-value pair is already made unique with the `matrix.suite` property.