### PR TITLE
using platform-family instead of just individual platform names

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ end
 
 begin
   RuboCop::RakeTask.new(:lint) do |task|
-    task.options += %w(--display-cop-names --no-color --parallel)
+    task.options += %w[--display-cop-names --no-color --parallel]
   end
 rescue LoadError
   puts 'rubocop is not available. Install the rubocop gem to run the lint tests.'

--- a/controls/SV-230475.rb
+++ b/controls/SV-230475.rb
@@ -62,13 +62,13 @@ integrity of the audit tools.
     !virtualization.system.eql?('docker')
   }
 
-  audit_tools = %w(/usr/sbin/auditctl
+  audit_tools = %w[/usr/sbin/auditctl
                    /usr/sbin/auditd
                    /usr/sbin/ausearch
                    /usr/sbin/aureport
                    /usr/sbin/autrace
                    /usr/sbin/rsyslogd
-                   /usr/sbin/augenrules)
+                   /usr/sbin/augenrules]
 
   if package('aide').installed?
     audit_tools.each do |tool|

--- a/inspec.yml
+++ b/inspec.yml
@@ -9,9 +9,7 @@ version: 1.14.1
 inspec_version: ">= 5.0"
 
 supports:
-  - platform-name: centos
-    release: 8.*
-  - platform-name: redhat
+  - platform-family: redhat
     release: 8.*
 
 ### INPUTS ###


### PR DESCRIPTION
Checked that using `platform-family` this way works against Rocky Linux (as expected) at version 8 but not 9 (as expected).

```bash
$> cinc-auditor exec https://github.com/mitre/redhat-enterprise-linux-8-stig-baseline/archive/platform-family.tar.gz -t podman://rocky8 --controls=SV-257258

Profile:   redhat-enterprise-linux-8-stig-baseline (redhat-enterprise-linux-8-stig-baseline)
Version:   1.14.1
Target:    podman://98fa15750fd566d489812c00f3954bca893ec94d618e71128204bafd4df737a3
Target ID: 635932fc-e45b-54ef-a5e2-3e239161c4e2

  ↺  SV-257258: RHEL 8 must terminate idle user sessions.
     ↺  Can't find file: /etc/systemd/logind.conf


Profile Summary: 0 successful controls, 0 control failures, 1 control skipped
Test Summary: 0 successful, 0 failures, 1 skipped

$>  cinc-auditor exec https://github.com/mitre/redhat-enterprise-linux-8-stig-baseline/archive/platform-family.tar.gz -t podman://rocky9 --controls=SV-257258
Skipping profile: 'redhat-enterprise-linux-8-stig-baseline' on unsupported platform: 'rocky/9.5'.

Test Summary: 0 successful, 0 failures, 0 skipped
```