### PR TITLE
Pki cert dynamic

### DIFF
--- a/controls/SV-230229.rb
+++ b/controls/SV-230229.rb
@@ -70,19 +70,29 @@ Obtain a valid copy of the DoD root CA file from the PKI CA certificate bundle a
   }
 
   root_ca_file = input('root_ca_file')
-  describe file(root_ca_file) do
+  root_ca_file_path = root_ca_file['path']
+
+  # Ensure the file exists
+  describe file(root_ca_file_path) do
     it { should exist }
   end
 
+  # Check the Root CA's validity and details
   describe 'Ensure the RootCA is a DoD-issued certificate with a valid date' do
-    if file(root_ca_file).exist?
-      subject { x509_certificate(root_ca_file) }
+    if file(root_ca_file_path).exist?
+      subject { x509_certificate(root_ca_file_path) }
+
+      # Verify that the issuer_dn matches the expected issuer DN
       it 'has the correct issuer_dn' do
-        expect(subject.issuer_dn).to match('/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 3')
+        expect(subject.issuer_dn).to match(root_ca_file['issue_dn'])
       end
+
+      # Verify that the subject_dn matches the expected subject DN
       it 'has the correct subject_dn' do
-        expect(subject.subject_dn).to match('/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 3')
+        expect(subject.subject_dn).to match(root_ca_file['subject_dn'])
       end
+
+      # Ensure that the certificate is valid (i.e., it hasn't expired)
       it 'is valid' do
         expect(subject.validity_in_days).to be > 0
       end

--- a/controls/SV-230229.rb
+++ b/controls/SV-230229.rb
@@ -69,8 +69,10 @@ Obtain a valid copy of the DoD root CA file from the PKI CA certificate bundle a
     !input('smart_card_enabled')
   }
 
-  root_ca_file = input('root_ca_file')
-  root_ca_file_path = root_ca_file['path']
+  root_ca_file = input('root_ca_file') # This gets the entire hash from input
+  root_ca_file_path = root_ca_file['path'] # Extract the path for file operations
+  issuer_dn_expected = root_ca_file['issuer_dn'] # Extract the expected issuer DN
+  subject_dn_expected = root_ca_file['subject_dn'] # Extract the expected subject DN
 
   # Ensure the file exists
   describe file(root_ca_file_path) do
@@ -84,12 +86,12 @@ Obtain a valid copy of the DoD root CA file from the PKI CA certificate bundle a
 
       # Verify that the issuer_dn matches the expected issuer DN
       it 'has the correct issuer_dn' do
-        expect(subject.issuer_dn).to match(root_ca_file['issue_dn'])
+        expect(subject.issuer_dn).to match(issuer_dn_expected) # Match the expected issuer DN
       end
 
       # Verify that the subject_dn matches the expected subject DN
       it 'has the correct subject_dn' do
-        expect(subject.subject_dn).to match(root_ca_file['subject_dn'])
+        expect(subject.subject_dn).to match(subject_dn_expected) # Match the expected subject DN
       end
 
       # Ensure that the certificate is valid (i.e., it hasn't expired)

--- a/inspec.yml
+++ b/inspec.yml
@@ -13,7 +13,7 @@ supports:
     release: 8.*
 
 ### INPUTS ###
-# Inputs are variables that can be referenced by any control in the profile, 
+# Inputs are variables that can be referenced by any control in the profile,
 # and are defined and given a default value in this file.
 
 # By default, each parameter is set to exactly comply with the STIG baseline
@@ -22,7 +22,7 @@ supports:
 
 # For example, control SV-230379 checks that only 'necessary accounts' exist
 # on the system. The list of 'necessary' accounts depends on the function of
-# the system, and you will likely need to add approved accounts to the 
+# the system, and you will likely need to add approved accounts to the
 # 'known_system_accounts' input. Also, depending on your local organizational
 # security policy, you may need to deviate from the STIG on some controls to
 # make the test profile 'stricter' or 'looser.'
@@ -350,7 +350,7 @@ inputs:
   - name: unapproved_ssl_tls_versions
     description:
     type: Array
-    value: 
+    value:
       - -VERS-DTLS0.9
       - -VERS-SSL3.0
       - -VERS-TLS1.0
@@ -469,8 +469,12 @@ inputs:
   # SV-230229
   - name: root_ca_file
     description: Path to an accepted trust anchor certificate file (DoD)
-    type: String
-    value: "/etc/sssd/pki/sssd_auth_ca_db.pem"
+    type: Hash
+    value:
+      path: "/etc/sssd/pki/sssd_auth_ca_db.pem"
+      issuer_dn: '/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 3'
+      subject_dn: '/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 3'
+
 
   # SV-230353
   - name: system_inactivity_timeout
@@ -920,7 +924,7 @@ inputs:
     description: Set to true if there is a documented requirement for the target system to use iprutils
     type: Boolean
     value: false
-  
+
     # SV-230561
   - name: tuned_required
     description: Set to true if there is a documented requirement for the target system to use tuned
@@ -1038,7 +1042,7 @@ inputs:
     description: The audit rules to be applied to the system
     type: Hash
     value: {}
-  
+
   # SV-230226
   - name: banner_message_db
     description: Database where the banner text message is expected to live

--- a/inspec.yml
+++ b/inspec.yml
@@ -475,7 +475,6 @@ inputs:
       issuer_dn: '/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 3'
       subject_dn: '/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 3'
 
-
   # SV-230353
   - name: system_inactivity_timeout
     description: Maximum system inactivity timeout (time in seconds).

--- a/inspec.yml
+++ b/inspec.yml
@@ -471,7 +471,7 @@ inputs:
     description: Path to an accepted trust anchor certificate file (DoD)
     type: Hash
     value:
-      path: "/etc/sssd/pki/sssd_auth_ca_db.pem"
+      path: "/etc/sssd/pki/sssd_auth_ca_db.pem" # https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_DoD.zip'
       issuer_dn: '/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 3'
       subject_dn: '/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 3'
 


### PR DESCRIPTION
Latest has updated subject and issuer version

https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_DoD.zip

```
root_ca_file:
  path: "/etc/sssd/pki/sssd_auth_ca_db.pem"
  issuer_dn: '/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 6'
  subject_dn: '/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DoD Root CA 6'
```

Updated Feb 19th 2025
