### PR TITLE
Account for arrays or strings in audit rule SV-230386

### DIFF
--- a/controls/SV-230386.rb
+++ b/controls/SV-230386.rb
@@ -67,14 +67,14 @@ this is a finding.'
         end
         expect(audit_rule.fields.flatten).to include('uid!=euid', 'gid!=egid', 'euid=0', 'egid=0')
 
-        # Ensure both inputs are arrays (if already arrays, they remain unchanged)
-        audit_rule_keynames = Array(input('audit_rule_keynames'))
-        audit_rule_keynames_overrides = Array(input('audit_rule_keynames_overrides'))
+        # Load the audit rule keynames and overrides from the input as hashes
+        audit_rule_keynames = input('audit_rule_keynames')
+        audit_rule_keynames_overrides = input('audit_rule_keynames_overrides')
 
-        # Merge the two arrays and ensure uniqueness
-        merged_keys = (audit_rule_keynames + audit_rule_keynames_overrides).uniq
+        # Merge the two hashes with overrides taking precedence
+        merged_keys = audit_rule_keynames.merge(audit_rule_keynames_overrides)
 
-        # Perform the expectation check
+        # Perform the expectation check that the audit rule's unique key exists within the merged keys
         expect(audit_rule.key.uniq).to include(merged_keys[audit_syscall])
       end
     end

--- a/controls/SV-230386.rb
+++ b/controls/SV-230386.rb
@@ -66,7 +66,16 @@ this is a finding.'
           expect(audit_rule.arch.uniq).to cmp 'b32'
         end
         expect(audit_rule.fields.flatten).to include('uid!=euid', 'gid!=egid', 'euid=0', 'egid=0')
-        expect(audit_rule.key.uniq).to include(input('audit_rule_keynames').merge(input('audit_rule_keynames_overrides'))[audit_syscall])
+
+        # Ensure both inputs are arrays (if already arrays, they remain unchanged)
+        audit_rule_keynames = Array(input('audit_rule_keynames'))
+        audit_rule_keynames_overrides = Array(input('audit_rule_keynames_overrides'))
+
+        # Merge the two arrays and ensure uniqueness
+        merged_keys = (audit_rule_keynames + audit_rule_keynames_overrides).uniq
+
+        # Perform the expectation check
+        expect(audit_rule.key.uniq).to include(merged_keys[audit_syscall])
       end
     end
   end

--- a/controls/SV-230386.rb
+++ b/controls/SV-230386.rb
@@ -80,6 +80,7 @@ this is a finding.'
         # Check that all expected keys are present
         # Splat operator (*) is used to expand the array into individual arguments
         expect(audit_rule.key.uniq).to include(*expected_keys)
+      end
     end
   end
 end

--- a/controls/SV-230386.rb
+++ b/controls/SV-230386.rb
@@ -74,9 +74,12 @@ this is a finding.'
         # Merge the two hashes with overrides taking precedence
         merged_keys = audit_rule_keynames.merge(audit_rule_keynames_overrides)
 
-        # Perform the expectation check that the audit rule's unique key exists within the merged keys
-        expect(audit_rule.key.uniq).to include(merged_keys[audit_syscall])
-      end
+        # Get expected keys, automatically convert to array
+        expected_keys = Array(merged_keys[audit_syscall])
+
+        # Check that all expected keys are present
+        # Splat operator (*) is used to expand the array into individual arguments
+        expect(audit_rule.key.uniq).to include(*expected_keys)
     end
   end
 end


### PR DESCRIPTION
update SV-230386 to account for audit_rule_keynames being an array or a string